### PR TITLE
Change the post method return type to GraphQLResponse

### DIFF
--- a/graphql-webclient/src/main/java/graphql/kickstart/spring/webclient/boot/GraphQLResponse.java
+++ b/graphql-webclient/src/main/java/graphql/kickstart/spring/webclient/boot/GraphQLResponse.java
@@ -6,7 +6,7 @@ import java.util.Map.Entry;
 import lombok.Data;
 
 @Data
-class GraphQLResponse {
+public class GraphQLResponse {
 
   private Map<String, Object> data;
   private List<GraphQLError> errors;

--- a/graphql-webclient/src/main/java/graphql/kickstart/spring/webclient/boot/GraphQLWebClient.java
+++ b/graphql-webclient/src/main/java/graphql/kickstart/spring/webclient/boot/GraphQLWebClient.java
@@ -16,7 +16,7 @@ public interface GraphQLWebClient {
 
   <T> Mono<T> post(String resource, Map<String, Object> variables, Class<T> returnType);
 
-  <T> Mono<T> post(GraphQLRequest<T> request);
+  Mono<GraphQLResponse> post(GraphQLRequest<?> request);
 
   <T> Flux<T> flux(String resource, Class<T> returnType);
 

--- a/graphql-webclient/src/main/java/graphql/kickstart/spring/webclient/boot/GraphQLWebClientImpl.java
+++ b/graphql-webclient/src/main/java/graphql/kickstart/spring/webclient/boot/GraphQLWebClientImpl.java
@@ -35,8 +35,13 @@ class GraphQLWebClientImpl implements GraphQLWebClient {
   }
 
   @Override
-  public <T> Mono<T> post(GraphQLRequest<T> request) {
-    return execute(request).map(it -> readValue(it, request.getReturnType()));
+  public Mono<GraphQLResponse> post(GraphQLRequest<?> request) {
+    WebClient.RequestBodySpec spec = webClient.post()
+            .contentType(MediaType.APPLICATION_JSON);
+    request.getHeaders().forEach((header, values) -> spec.header(header, values.toArray(new String[0])));
+    return spec.bodyValue(request.getRequestBody())
+            .retrieve()
+            .bodyToMono(GraphQLResponse.class);
   }
 
   @Override

--- a/graphql-webclient/src/test/java/graphql/kickstart/spring/webclient/boot/GraphQLWebClientTest.java
+++ b/graphql-webclient/src/test/java/graphql/kickstart/spring/webclient/boot/GraphQLWebClientTest.java
@@ -72,11 +72,12 @@ class GraphQLWebClientTest {
         .resource("query-simple.graphql")
         .variables(Map.of("id", "my-id"))
         .build();
-    Mono<Simple> response = graphqlClient.post(request);
+    Mono<GraphQLResponse> response = graphqlClient.post(request);
     assertNotNull("response should not be null", response);
-    Simple object = response.block();
+    GraphQLResponse object = response.block();
     assertNotNull(object);
-    assertEquals("response id should equal 'my-id'", "my-id", object.getId());
+    Map<String,Object> simple = (Map<String, Object>) object.getData().get("simple");
+    assertEquals("response id should equal 'my-id'", "my-id", simple.get("id"));
   }
 
   @Test
@@ -107,9 +108,12 @@ class GraphQLWebClientTest {
         .variables(Map.of("name", "my-custom-header"))
         .header("my-custom-header", "my-custom-header-value")
         .build();
-    Mono<String> response = graphqlClient.post(request);
+    Mono<GraphQLResponse> response = graphqlClient.post(request);
     assertNotNull("response should not be null", response);
-    assertEquals("response should equal 'my-custom-header-value'", "my-custom-header-value", response.block());
+    assertNotNull("response should not be null", response);
+    GraphQLResponse object = response.block();
+    assertNotNull(object);
+    assertEquals("response should equal 'my-custom-header-value'", "my-custom-header-value", object.getData().get("header"));
   }
 
 }


### PR DESCRIPTION
Change the post method return type to GraphQLResponse so that user can have their own logic for result mapping and error handling.