### PR TITLE
Added ability to set attributes on GraphQLRequest

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=1.0.1-SNAPSHOT
+version=1.1.0-SNAPSHOT
 
 PROJECT_GROUP = com.graphql-java-kickstart
 PROJECT_NAME = graphql-spring-webclient

--- a/graphql-webclient/src/main/java/graphql/kickstart/spring/webclient/boot/GraphQLRequest.java
+++ b/graphql-webclient/src/main/java/graphql/kickstart/spring/webclient/boot/GraphQLRequest.java
@@ -2,6 +2,8 @@ package graphql.kickstart.spring.webclient.boot;
 
 import org.springframework.http.HttpHeaders;
 
+import java.util.Map;
+
 public interface GraphQLRequest {
 
   static GraphQLRequestBuilder builder() {
@@ -11,5 +13,7 @@ public interface GraphQLRequest {
   GraphQLRequestBody getRequestBody();
 
   HttpHeaders getHeaders();
+
+  Map<String, Object> getAttributes();
 
 }

--- a/graphql-webclient/src/main/java/graphql/kickstart/spring/webclient/boot/GraphQLRequestBuilder.java
+++ b/graphql-webclient/src/main/java/graphql/kickstart/spring/webclient/boot/GraphQLRequestBuilder.java
@@ -4,6 +4,9 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
 import lombok.SneakyThrows;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.Resource;
@@ -12,10 +15,16 @@ import org.springframework.util.StreamUtils;
 
 public class GraphQLRequestBuilder {
 
+  private final Map<String, Object> attributes = new LinkedHashMap<>();
   private final HttpHeaders headers = new HttpHeaders();
   private final GraphQLRequestBody.GraphQLRequestBodyBuilder bodyBuilder = GraphQLRequestBody.builder();
 
   GraphQLRequestBuilder() {
+  }
+
+  public GraphQLRequestBuilder attribute(String name, Object value) {
+    attributes.put(name, value);
+    return this;
   }
 
   public GraphQLRequestBuilder header(String name, String... values) {
@@ -54,7 +63,7 @@ public class GraphQLRequestBuilder {
   }
 
   public GraphQLRequest build() {
-    return new GraphQLRequestImpl(headers, bodyBuilder.build());
+    return new GraphQLRequestImpl(attributes, headers, bodyBuilder.build());
   }
 
 }

--- a/graphql-webclient/src/main/java/graphql/kickstart/spring/webclient/boot/GraphQLRequestImpl.java
+++ b/graphql-webclient/src/main/java/graphql/kickstart/spring/webclient/boot/GraphQLRequestImpl.java
@@ -3,9 +3,12 @@ package graphql.kickstart.spring.webclient.boot;
 import lombok.Value;
 import org.springframework.http.HttpHeaders;
 
+import java.util.Map;
+
 @Value
 class GraphQLRequestImpl implements GraphQLRequest {
 
+  Map<String, Object> attributes;
   HttpHeaders headers;
   GraphQLRequestBody requestBody;
 

--- a/graphql-webclient/src/main/java/graphql/kickstart/spring/webclient/boot/GraphQLWebClientImpl.java
+++ b/graphql-webclient/src/main/java/graphql/kickstart/spring/webclient/boot/GraphQLWebClientImpl.java
@@ -33,6 +33,8 @@ class GraphQLWebClientImpl implements GraphQLWebClient {
   @Override
   public Mono<GraphQLResponse> post(GraphQLRequest request) {
     WebClient.RequestBodySpec spec = webClient.post().contentType(MediaType.APPLICATION_JSON);
+    request.getAttributes()
+        .forEach(spec::attribute);
     request.getHeaders()
         .forEach((header, values) -> spec.header(header, values.toArray(new String[0])));
     return spec.bodyValue(request.getRequestBody())


### PR DESCRIPTION
(similar to Spring's ClientRequest)
One usecase is for us to customize metrics tags by overriding DefaultWebClientExchangeTagsProvider and fetching the custom tag values from ClientRequest.attribute().