### PR TITLE
feat: added json path features to GraphQLResponse

### DIFF
--- a/graphql-webclient/build.gradle
+++ b/graphql-webclient/build.gradle
@@ -1,5 +1,6 @@
 dependencies {
     api "org.springframework.boot:spring-boot-starter-webflux"
+    implementation "com.jayway.jsonpath:json-path:2.8.0"
 
     testImplementation "org.springframework.boot:spring-boot-starter-webflux"
     testImplementation "org.springframework.boot:spring-boot-starter-test"

--- a/graphql-webclient/src/main/java/graphql/kickstart/spring/webclient/boot/GraphQLResponseReadException.java
+++ b/graphql-webclient/src/main/java/graphql/kickstart/spring/webclient/boot/GraphQLResponseReadException.java
@@ -1,0 +1,7 @@
+package graphql.kickstart.spring.webclient.boot;
+
+import lombok.experimental.StandardException;
+
+@StandardException
+public class GraphQLResponseReadException extends RuntimeException {
+}

--- a/graphql-webclient/src/test/java/graphql/kickstart/spring/webclient/boot/GraphQLResponseTest.java
+++ b/graphql-webclient/src/test/java/graphql/kickstart/spring/webclient/boot/GraphQLResponseTest.java
@@ -1,6 +1,7 @@
 package graphql.kickstart.spring.webclient.boot;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -12,7 +13,11 @@ import static org.mockito.Mockito.verify;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jayway.jsonpath.PathNotFoundException;
+
 import java.util.List;
+import java.util.Map;
+
 import org.junit.jupiter.api.Test;
 
 class GraphQLResponseTest {
@@ -93,6 +98,85 @@ class GraphQLResponseTest {
     List<String> values = response.getList("field", String.class);
     assertEquals(1, values.size());
     assertEquals("value", values.get(0));
+  }
+
+  @Test
+  void getAt_dataFieldExists_returnsValue() {
+    GraphQLResponse response = constructResponse("{ \"data\": { \"field\": { \"innerField\": \"value\" } } }");
+    String value = response.getAt("field.innerField", String.class);
+    assertEquals("value", value);
+  }
+
+  @Test
+  void getAt_noDataFieldExists_throwsException() {
+    GraphQLResponse response = constructResponse("{ \"data\": { \"field\": { } } }");
+    GraphQLResponseReadException ex = assertThrows(GraphQLResponseReadException.class, () -> response.getAt("field.innerField", String.class));
+    assertInstanceOf(PathNotFoundException.class, ex.getCause());
+  }
+
+  @Test
+  void getAt_dataIsNull_returnsNull() {
+    GraphQLResponse response = constructResponse("{ \"data\": { \"field\": { \"innerField\": null } } }");
+    assertNull(response.getAt("field.innerField", String.class));
+  }
+
+  @Test
+  void getListAt_dataFieldExists_returnsList() {
+    GraphQLResponse response = constructResponse("{ \"data\": { \"field\": { \"innerField\": [\"value\"] } } }");
+    List<String> values = response.getListAt("field.innerField", String.class);
+    assertEquals(1, values.size());
+    assertEquals("value", values.get(0));
+  }
+
+  @Test
+  void getListAt_dataIsNull_returnsNull() {
+    GraphQLResponse response = constructResponse("{ \"data\": { \"field\": { \"innerField\": null } } }");
+    assertNull(response.getListAt("field.innerField", String.class));
+  }
+
+  @Test
+  void getListAt_noDataFieldExists_throwsException() {
+    GraphQLResponse response = constructResponse("{ \"data\": { \"field\": { } } }");
+    GraphQLResponseReadException ex = assertThrows(GraphQLResponseReadException.class, () -> response.getListAt("field.innerField", String.class));
+    assertInstanceOf(PathNotFoundException.class, ex.getCause());
+  }
+
+  @Test
+  void getAtAutoCast_dataFieldExists_returnsMap() {
+    GraphQLResponse response = constructResponse("{ \"data\": { \"field\": { \"innerField\": { \"blah\": \"value\" } } } }");
+    Map<String, String> value = response.getAt("field.innerField");
+    assertEquals(1, value.size());
+    assertEquals("value", value.get("blah"));
+  }
+
+  @Test
+  void getAtAutoCast_dataFieldExists_returnsString() {
+    GraphQLResponse response = constructResponse("{ \"data\": { \"field\": { \"innerField\": \"value\" } } }");
+    String value = response.getAt("field.innerField");
+    assertEquals("value", value);
+  }
+
+  @Test
+  void getAtAutoCast_dataFieldExists_returnsInt() {
+    GraphQLResponse response = constructResponse("{ \"data\": { \"field\": { \"innerField\": 42 } } }");
+    Integer value = response.getAt("field.innerField");
+    assertEquals(42, value);
+  }
+
+  @Test
+  void getAtAutoCast_dataFieldExists_returnsDouble() {
+    GraphQLResponse response = constructResponse("{ \"data\": { \"field\": { \"innerField\": 42.5 } } }");
+    Double value = response.getAt("field.innerField");
+    assertEquals(42.5, value);
+  }
+
+  @Test
+  void getAtAutoCast_dataFieldExists_returnsList() {
+    GraphQLResponse response = constructResponse("{ \"data\": { \"field\": { \"innerField\": [ \"value\", 42 ] } } }");
+    List<Object> values = response.getAt("field.innerField");
+    assertEquals(2, values.size());
+    assertEquals("value", values.get(0));
+    assertEquals(42, values.get(1));
   }
 
 }


### PR DESCRIPTION
Adds JsonPath features to `GraphQLResponse`. See #136 for details.

I wanted to ensure that this remained backward compatible, so I created new methods that would ensure there would be no breaking changes: `getAt(String, Class)`, `getAt(String)`, and `getListAt(String, Class)`.

I do believe that the implementations of `get` and `getList` could be updated to support JsonPath without breaking backward compatibility. However, I wanted to err on the side of caution and I don't know what the preference of the maintainers would be either. I'm happy to make any needed changes as well.