### PR TITLE
feat: added retry options

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,15 @@ should be defined as `graphql.client.url` in your Spring Boot configuration file
 | `oauth2.client-secret` | OAuth2 client secret |
 | `oauth2.token-uri` | Token URI of the identity provider |
 | `oauth2.authorization-grant-type` | By default the grant type `client_credentials` is used |
- 
+| `retry.strategy` | The retry strategy to auto configure for the `WebClient` _(possible values are `none`, `backoff`, `fixed_delay`, `indefinitely`, `max` and `max_in_row`)_. Default is `none`. |
+| `retry.backoff.max-attempts` | The maximum number of retry attempts to allow _(only used when `retry.strategy` = `backoff`)_. |
+| `retry.backoff.min-backoff` | The minimum duration for the first backoff _(only used when `retry.strategy` = `backoff`)_. Default is `0`. |
+| `retry.backoff.max-backoff` | The maximum duration for the exponential backoffs _(only used when `retry.strategy` = `backoff`)_. Default is `Duration.ofMillis(Long.MAX_VALUE)`. |
+| `retry.fixed-delay.max-attempts` | The maximum number of retry attempts to allow _(only used when `retry.strategy` = `fixed_delay`)_. |
+| `retry.fixed-delay.delay` | The duration of the fixed delays between attempts _(only used when `retry.strategy` = `fixed_delay`)_. |
+| `retry.max.max-attempts` | The maximum number of retry attempts to allow _(only used when `retry.strategy` = `max`)_. |
+| `retry.max-in-row.max-attempts` | The maximum number of retry attempts to allow in a row _(only used when `retry.strategy` = `max_in_row`)_. |
+
 ### Max in memory size
 
 In case you need to work with large responses you might run into the following error:

--- a/graphql-webclient-spring-boot-autoconfigure/src/main/java/graphql/kickstart/spring/webclient/boot/GraphQLClientRetryProperties.java
+++ b/graphql-webclient-spring-boot-autoconfigure/src/main/java/graphql/kickstart/spring/webclient/boot/GraphQLClientRetryProperties.java
@@ -1,0 +1,52 @@
+package graphql.kickstart.spring.webclient.boot;
+
+import java.time.Duration;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Primary;
+
+import lombok.Data;
+
+@Data
+@Primary
+@ConfigurationProperties("graphql.client.retry")
+public class GraphQLClientRetryProperties {
+
+  private RetryStrategy strategy = RetryStrategy.NONE;
+  private RetryBackoff backoff = new RetryBackoff();
+  private RetryFixedDelay fixedDelay = new RetryFixedDelay();
+  private RetryMax max = new RetryMax();
+  private RetryMaxInRow maxInRow = new RetryMaxInRow();
+
+  @Data
+  static class RetryBackoff {
+    private long maxAttempts = -1;
+    private Duration minBackoff = Duration.ofMillis(0);
+    private Duration maxBackoff = Duration.ofMillis(Long.MAX_VALUE);
+  }
+
+  @Data
+  static class RetryFixedDelay {
+    private long maxAttempts = -1;
+    private Duration delay = Duration.ofMillis(0);
+  }
+
+  @Data
+  static class RetryMax {
+    private long maxAttempts = -1;
+  }
+
+  @Data
+  static class RetryMaxInRow {
+    private long maxAttempts = -1;
+  }
+
+  enum RetryStrategy {
+    BACKOFF,
+    FIXED_DELAY,
+    INDEFINITELY,
+    MAX,
+    MAX_IN_ROW,
+    NONE
+  }
+}

--- a/graphql-webclient-spring-boot-autoconfigure/src/main/java/graphql/kickstart/spring/webclient/boot/GraphQLWebClientRetryErrorFilterPredicate.java
+++ b/graphql-webclient-spring-boot-autoconfigure/src/main/java/graphql/kickstart/spring/webclient/boot/GraphQLWebClientRetryErrorFilterPredicate.java
@@ -1,0 +1,6 @@
+package graphql.kickstart.spring.webclient.boot;
+
+import java.util.function.Predicate;
+
+public interface GraphQLWebClientRetryErrorFilterPredicate extends Predicate<Throwable> {
+}

--- a/graphql-webclient-spring-boot-autoconfigure/src/main/java/graphql/kickstart/spring/webclient/boot/GraphQLWebClientRetryProvider.java
+++ b/graphql-webclient-spring-boot-autoconfigure/src/main/java/graphql/kickstart/spring/webclient/boot/GraphQLWebClientRetryProvider.java
@@ -1,0 +1,7 @@
+package graphql.kickstart.spring.webclient.boot;
+
+import reactor.util.retry.Retry;
+
+public interface GraphQLWebClientRetryProvider {
+  Retry get();
+}

--- a/graphql-webclient/src/main/java/graphql/kickstart/spring/webclient/boot/GraphQLWebClient.java
+++ b/graphql-webclient/src/main/java/graphql/kickstart/spring/webclient/boot/GraphQLWebClient.java
@@ -5,11 +5,16 @@ import java.util.Map;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+import reactor.util.retry.Retry;
 
 public interface GraphQLWebClient {
 
   static GraphQLWebClient newInstance(WebClient webClient, ObjectMapper objectMapper) {
-    return new GraphQLWebClientImpl(webClient, objectMapper);
+    return GraphQLWebClient.newInstance(webClient, objectMapper, null);
+  }
+
+  static GraphQLWebClient newInstance(WebClient webClient, ObjectMapper objectMapper, Retry retry) {
+    return new GraphQLWebClientImpl(webClient, objectMapper, retry);
   }
 
   <T> Mono<T> post(String resource, Class<T> returnType);


### PR DESCRIPTION
Add ability to auto-configure retry options when calling `post` in `GraphQLWebClientImpl`.